### PR TITLE
Resolved issues with accessing token later.

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -5,6 +5,7 @@ namespace SocialiteProviders\Yahoo;
 use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use Illuminate\Support\Arr;
 
 class Provider extends AbstractProvider implements ProviderInterface
 {
@@ -12,6 +13,11 @@ class Provider extends AbstractProvider implements ProviderInterface
      * Unique Provider Identifier.
      */
     const IDENTIFIER = 'YAHOO';
+
+    /**
+     * @var string
+     */
+    protected $xoauth_yahoo_guid;
 
     /**
      * {@inheritdoc}
@@ -34,9 +40,9 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://social.yahooapis.com/v1/user/'.$token['xoauth_yahoo_guid'].'/profile?format=json', [
+        $response = $this->getHttpClient()->get('https://social.yahooapis.com/v1/user/'. $this->xoauth_yahoo_guid .'/profile?format=json', [
             'headers' => [
-                'Authorization' => 'Bearer '.$token['access_token'],
+                'Authorization' => 'Bearer '.$token,
             ],
         ]);
 
@@ -78,6 +84,8 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function parseAccessToken($body)
     {
-        return (array) $body;
+        $this->xoauth_yahoo_guid = Arr::get($body, 'xoauth_yahoo_guid');
+
+        return Arr::get($body, 'access_token');
     }
 }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -44,13 +44,18 @@ class Provider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Maps Yahoo object to User Object
+     * 
+     * Note: To have access to e-mail, you need to request "Profiles (Social Directory) - Read/Write Public and Private"
      */
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id' => $user['guid'], 'nickname' => $user['nickname'], 'name' => null,
-            'email' => null, 'avatar' => $user['image']['imageUrl'],
+            'id' => $user['guid'],
+            'nickname' => $user['nickname'],
+            'name' => null,
+            'email' => isset($user['emails'][0]['handle']) ? $user['emails'][0]['handle'] : null,
+            'avatar' => $user['image']['imageUrl'],
         ]);
     }
 
@@ -73,6 +78,6 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function parseAccessToken($body)
     {
-        return json_decode($body, true);
+        return (array) $body;
     }
 }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -45,7 +45,7 @@ class Provider extends AbstractProvider implements ProviderInterface
 
     /**
      * Maps Yahoo object to User Object.
-     * 
+     *
      * Note: To have access to e-mail, you need to request "Profiles (Social Directory) - Read/Write Public and Private"
      */
     protected function mapUserToObject(array $user)

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -44,7 +44,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Maps Yahoo object to User Object
+     * Maps Yahoo object to User Object.
      * 
      * Note: To have access to e-mail, you need to request "Profiles (Social Directory) - Read/Write Public and Private"
      */


### PR DESCRIPTION
I had to redo how Yahoo's xoauth_yahoo_guid was being set. While the last fix resolved the problem initially, if you ever tried to access the token later it was not a string but an array which is inconsistent for how all other providers display the token variable.
